### PR TITLE
Add model mapping utilities

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -17,6 +17,12 @@ const AVAILABLE_MODELS = {
   }
 };
 
+/**
+ * Retrieves the slug for the specified model name.
+ *
+ * @param {string} name - The name of the model (e.g., 'gpt4o', 'gpt41', 'claude3', 'gemini').
+ * @returns {string|null} The slug associated with the model name, or null if the name is unsupported.
+ */
 function getOpenRouterSlug(name) {
   return AVAILABLE_MODELS[name] ? AVAILABLE_MODELS[name].slug : null;
 }

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -1,0 +1,28 @@
+const AVAILABLE_MODELS = {
+  gpt4o: {
+    slug: 'openai/gpt-4.1',
+    display: 'GPT-4.1'
+  },
+  gpt41: {
+    slug: 'openai/gpt-4.1',
+    display: 'GPT-4.1'
+  },
+  claude3: {
+    slug: 'anthropic/claude-3.7-sonnet',
+    display: 'Claude 3.7'
+  },
+  gemini: {
+    slug: 'google/gemini-2.5-pro-preview',
+    display: 'Gemini 2.5'
+  }
+};
+
+function getOpenRouterSlug(name) {
+  return AVAILABLE_MODELS[name] ? AVAILABLE_MODELS[name].slug : null;
+}
+
+function getDisplayName(name) {
+  return AVAILABLE_MODELS[name] ? AVAILABLE_MODELS[name].display : name;
+}
+
+module.exports = { AVAILABLE_MODELS, getOpenRouterSlug, getDisplayName };

--- a/src/routes/mvp.js
+++ b/src/routes/mvp.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const mvpController = require('../controllers/mvpController');
+const { AVAILABLE_MODELS } = require("../lib/models");
 const { verifyAuth, requireAuth } = require('../middleware/auth');
 
 // GET /api/mvp/demo - Demo endpoint
@@ -10,6 +11,7 @@ router.get('/demo', (req, res) => {
     endpoints: [
       // { method: 'POST', path: '/api/mvp/evaluate', description: 'Evaluate a single question (currently under review)' },
       { method: 'POST', path: '/api/mvp/evaluate-set', description: 'Evaluate multiple questions in batch' },
+        { method: 'GET', path: '/api/mvp/models', description: 'List available models' },
       { method: 'GET', path: '/api/mvp/sets', description: 'Get all evaluation sets (in-memory)' },
       { method: 'GET', path: '/api/mvp/sets/:id', description: 'Get a specific evaluation set (in-memory)' },
       { method: 'GET', path: '/api/mvp/share/:id', description: 'Get a shareable evaluation set (from Supabase)' }
@@ -17,6 +19,7 @@ router.get('/demo', (req, res) => {
     timestamp: new Date().toISOString()
   });
 });
+router.get("/models", (req, res) => { res.json(AVAILABLE_MODELS); });
 
 // POST /api/mvp/evaluate - Evaluate a single question
 // router.post('/evaluate', mvpController.evaluateModels); // evaluateModels is not in the new module.exports, functionality covered by evaluateSet or evaluateResponse


### PR DESCRIPTION
## Summary
- add a list of supported models
- expose an endpoint to list available models
- map model names to OpenRouter slugs using the new helper
- show display names via helper functions

## Testing
- `node --check src/controllers/mvpController.js`
- `node --check src/routes/mvp.js`
- `node --check src/lib/models.js`
