### PR TITLE
feat: update Gemini model to 2.5 Flash

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -12,8 +12,8 @@ const AVAILABLE_MODELS = {
     display: 'Claude Sonnet 4'
   },
   gemini: {
-    slug: 'google/gemini-2.5-pro-preview',
-    display: 'Gemini 2.5'
+    slug: 'google/gemini-2.5-flash-preview-05-20',
+    display: 'Gemini 2.5 Flash'
   }
 };
 


### PR DESCRIPTION
Replace Gemini 2.5 Pro with Gemini 2.5 Flash for better performance:
- Update model slug to google/gemini-2.5-flash-preview-05-20
- Update display name to "Gemini 2.5 Flash"

🤖 Generated with [Claude Code](https://claude.ai/code)